### PR TITLE
Disallow building with GHC-7.2 + array-0.4

### DIFF
--- a/deepseq.cabal
+++ b/deepseq.cabal
@@ -48,6 +48,9 @@ library
     if impl(ghc < 7.6)
       build-depends: ghc-prim == 0.2.*
 
+  if impl(ghc < 7.4)
+    build-depends: array < 0.4
+
   build-depends: base       >= 4.3 && < 4.9,
                  array      >= 0.3 && < 0.6
   ghc-options: -Wall


### PR DESCRIPTION
```
[1 of 1] Compiling Control.DeepSeq  ( Control/DeepSeq.hs, dist/dist-sandbox-c66cf055/build/Control/DeepSeq.o )

Control/DeepSeq.hs:91:1:
    ghc-prim:GHC.Generics can't be safely imported! The module itself isn't safe.
```