### PR TITLE
Make NFData (Proxy a) instance poly-kinded

### DIFF
--- a/Control/DeepSeq.hs
+++ b/Control/DeepSeq.hs
@@ -8,6 +8,9 @@
 {-# LANGUAGE Safe #-}
 # endif
 #endif
+#if __GLASGOW_HASKELL__ >= 706
+{-# LANGUAGE PolyKinds #-}
+#endif
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Control.DeepSeq


### PR DESCRIPTION
Currently, you can't do something like `force (Proxy :: Proxy Maybe)`, since the `NFData (Proxy a)` instance assumes `a :: *`. Turning on `PolyKinds` on recent-enough GHCs allows the use of any kind.