### PR TITLE
Foreign.Ptr instances.

### DIFF
--- a/Control/DeepSeq.hs
+++ b/Control/DeepSeq.hs
@@ -71,6 +71,7 @@ import Data.Fixed
 import Data.Version
 import Data.Monoid
 import Data.Unique ( Unique )
+import Foreign.Ptr
 import Foreign.C.Types
 import System.Mem.StableName ( StableName )
 
@@ -419,6 +420,15 @@ instance NFData TyCon where
 instance NFData Fingerprint where
     rnf (Fingerprint _ _) = ()
 #endif
+
+----------------------------------------------------------------------------
+-- Foreign.Ptr
+
+-- |/Since: 1.4.3.0/
+instance NFData (Ptr a) where rnf !_ = ()
+
+-- |/Since: 1.4.3.0/
+instance NFData (FunPtr a) where rnf !_ = ()
 
 ----------------------------------------------------------------------------
 -- Foreign.C.Types


### PR DESCRIPTION
deepseq currently defines instances for `Foreign.C.Types`, but not for
`Ptr` and `FunPtr`, both exported from `Foreign.Ptr`. This PR remedies
the situation.

I believe that the PVP does not require a major version bump here,
since the extra instances are not orphan instances. But feel free to
modify the "Since:" Haddock annotation accordingly.