### PR TITLE
Bump HUnit upper bound

### DIFF
--- a/deepseq.cabal
+++ b/deepseq.cabal
@@ -84,4 +84,4 @@ test-suite deepseq-generics-tests
         -- end of packages with inherited version constraints
         test-framework == 0.8.*,
         test-framework-hunit == 0.3.*,
-        HUnit == 1.2.*
+        HUnit >= 1.2 && < 1.4


### PR DESCRIPTION
Seems to build fine with HUnit 1.3 and the tests are green.