### PR TITLE
Add rnfFoldableLTR and rnfFoldableRTL

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog for [`deepseq` package](http://hackage.haskell.org/package/deepseq)
 
+## ????
+
+  * New functions `rnfFoldableLTR` and `rnfFoldableRTL`
+
 ## 1.4.2.0  *Apr 2016*
 
   * Bundled with GHC 8.0.1

--- a/deepseq.cabal
+++ b/deepseq.cabal
@@ -53,6 +53,11 @@ library
     if impl(ghc < 7.6)
       build-depends: ghc-prim == 0.2.*
 
+  if impl(ghc >= 7.8)
+    other-extensions:
+      ScopedTypeVariables
+      Trustworthy
+
   if impl(ghc < 7.4)
     build-depends: array < 0.4
 


### PR DESCRIPTION
If a type has a `Foldable` instance, then we can force it from
left to right or from right to left.

Fixes #17
