### PR TITLE
Fix GNFData instance for V1

### DIFF
--- a/Control/DeepSeq.hs
+++ b/Control/DeepSeq.hs
@@ -11,6 +11,9 @@
 #if __GLASGOW_HASKELL__ >= 706
 {-# LANGUAGE PolyKinds #-}
 #endif
+#if __GLASGOW_HASKELL__ >= 708
+{-# LANGUAGE EmptyCase #-}
+#endif
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Control.DeepSeq
@@ -114,7 +117,11 @@ class GNFData f where
   grnf :: f a -> ()
 
 instance GNFData V1 where
-  grnf = error "Control.DeepSeq.rnf: uninhabited type"
+#if __GLASGOW_HASKELL__ >= 708
+  grnf x = case x of {}
+#else
+  grnf !_ = error "Control.DeepSeq.rnf: uninhabited type"
+#endif
 
 instance GNFData U1 where
   grnf U1 = ()


### PR DESCRIPTION
Make `grnf` for `V1` a well-defined function that forces its
(bottom) argument rather than making the function itself bottom.

Fixes #19