### PR TITLE
Run tests on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,60 +13,60 @@ before_cache:
 
 matrix:
   include:
-    - env: CABALVER=1.16 GHCVER=7.0.1
+    - env: CABALVER=1.24 GHCVER=7.0.1
       compiler: ": #GHC 7.0.1"
-      addons: {apt: {packages: [cabal-install-1.16,ghc-7.0.1], sources: [hvr-ghc]}}
-    - env: CABALVER=1.16 GHCVER=7.0.2
+      addons: {apt: {packages: [cabal-install-1.24,ghc-7.0.1], sources: [hvr-ghc]}}
+    - env: CABALVER=1.24 GHCVER=7.0.2
       compiler: ": #GHC 7.0.2"
-      addons: {apt: {packages: [cabal-install-1.16,ghc-7.0.2], sources: [hvr-ghc]}}
-    - env: CABALVER=1.16 GHCVER=7.0.3
+      addons: {apt: {packages: [cabal-install-1.24,ghc-7.0.2], sources: [hvr-ghc]}}
+    - env: CABALVER=1.24 GHCVER=7.0.3
       compiler: ": #GHC 7.0.3"
-      addons: {apt: {packages: [cabal-install-1.16,ghc-7.0.3], sources: [hvr-ghc]}}
-    - env: CABALVER=1.16 GHCVER=7.0.4
+      addons: {apt: {packages: [cabal-install-1.24,ghc-7.0.3], sources: [hvr-ghc]}}
+    - env: CABALVER=1.24 GHCVER=7.0.4
       compiler: ": #GHC 7.0.4"
-      addons: {apt: {packages: [cabal-install-1.16,ghc-7.0.4], sources: [hvr-ghc]}}
-    - env: CABALVER=1.16 GHCVER=7.2.1
+      addons: {apt: {packages: [cabal-install-1.24,ghc-7.0.4], sources: [hvr-ghc]}}
+    - env: CABALVER=1.24 GHCVER=7.2.1
       compiler: ": #GHC 7.2.1"
-      addons: {apt: {packages: [cabal-install-1.16,ghc-7.2.1], sources: [hvr-ghc]}}
-    - env: CABALVER=1.16 GHCVER=7.2.2
+      addons: {apt: {packages: [cabal-install-1.24,ghc-7.2.1], sources: [hvr-ghc]}}
+    - env: CABALVER=1.24 GHCVER=7.2.2
       compiler: ": #GHC 7.2.2"
-      addons: {apt: {packages: [cabal-install-1.16,ghc-7.2.2], sources: [hvr-ghc]}}
-    - env: CABALVER=1.16 GHCVER=7.4.1
+      addons: {apt: {packages: [cabal-install-1.24,ghc-7.2.2], sources: [hvr-ghc]}}
+    - env: CABALVER=1.24 GHCVER=7.4.1
       compiler: ": #GHC 7.4.1"
-      addons: {apt: {packages: [cabal-install-1.16,ghc-7.4.1], sources: [hvr-ghc]}}
-    - env: CABALVER=1.16 GHCVER=7.4.2
+      addons: {apt: {packages: [cabal-install-1.24,ghc-7.4.1], sources: [hvr-ghc]}}
+    - env: CABALVER=1.24 GHCVER=7.4.2
       compiler: ": #GHC 7.4.2"
-      addons: {apt: {packages: [cabal-install-1.16,ghc-7.4.2], sources: [hvr-ghc]}}
-    - env: CABALVER=1.16 GHCVER=7.6.1
+      addons: {apt: {packages: [cabal-install-1.24,ghc-7.4.2], sources: [hvr-ghc]}}
+    - env: CABALVER=1.24 GHCVER=7.6.1
       compiler: ": #GHC 7.6.1"
-      addons: {apt: {packages: [cabal-install-1.16,ghc-7.6.1], sources: [hvr-ghc]}}
-    - env: CABALVER=1.16 GHCVER=7.6.2
+      addons: {apt: {packages: [cabal-install-1.24,ghc-7.6.1], sources: [hvr-ghc]}}
+    - env: CABALVER=1.24 GHCVER=7.6.2
       compiler: ": #GHC 7.6.2"
-      addons: {apt: {packages: [cabal-install-1.16,ghc-7.6.2], sources: [hvr-ghc]}}
-    - env: CABALVER=1.16 GHCVER=7.6.3
+      addons: {apt: {packages: [cabal-install-1.24,ghc-7.6.2], sources: [hvr-ghc]}}
+    - env: CABALVER=1.24 GHCVER=7.6.3
       compiler: ": #GHC 7.6.3"
-      addons: {apt: {packages: [cabal-install-1.16,ghc-7.6.3], sources: [hvr-ghc]}}
-    - env: CABALVER=1.18 GHCVER=7.8.1
+      addons: {apt: {packages: [cabal-install-1.24,ghc-7.6.3], sources: [hvr-ghc]}}
+    - env: CABALVER=1.24 GHCVER=7.8.1
       compiler: ": #GHC 7.8.1"
-      addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.1], sources: [hvr-ghc]}}
-    - env: CABALVER=1.18 GHCVER=7.8.2
+      addons: {apt: {packages: [cabal-install-1.24,ghc-7.8.1], sources: [hvr-ghc]}}
+    - env: CABALVER=1.24 GHCVER=7.8.2
       compiler: ": #GHC 7.8.2"
-      addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.2], sources: [hvr-ghc]}}
-    - env: CABALVER=1.18 GHCVER=7.8.3
+      addons: {apt: {packages: [cabal-install-1.24,ghc-7.8.2], sources: [hvr-ghc]}}
+    - env: CABALVER=1.24 GHCVER=7.8.3
       compiler: ": #GHC 7.8.3"
-      addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.3], sources: [hvr-ghc]}}
-    - env: CABALVER=1.18 GHCVER=7.8.4
+      addons: {apt: {packages: [cabal-install-1.24,ghc-7.8.3], sources: [hvr-ghc]}}
+    - env: CABALVER=1.24 GHCVER=7.8.4
       compiler: ": #GHC 7.8.4"
-      addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4], sources: [hvr-ghc]}}
-    - env: CABALVER=1.22 GHCVER=7.10.1
+      addons: {apt: {packages: [cabal-install-1.24,ghc-7.8.4], sources: [hvr-ghc]}}
+    - env: CABALVER=1.24 GHCVER=7.10.1
       compiler: ": #GHC 7.10.1"
-      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.1], sources: [hvr-ghc]}}
-    - env: CABALVER=1.22 GHCVER=7.10.2
+      addons: {apt: {packages: [cabal-install-1.24,ghc-7.10.1], sources: [hvr-ghc]}}
+    - env: CABALVER=1.24 GHCVER=7.10.2
       compiler: ": #GHC 7.10.2"
-      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.2], sources: [hvr-ghc]}}
-    - env: CABALVER=1.22 GHCVER=7.10.3
+      addons: {apt: {packages: [cabal-install-1.24,ghc-7.10.2], sources: [hvr-ghc]}}
+    - env: CABALVER=1.24 GHCVER=7.10.3
       compiler: ": #GHC 7.10.3"
-      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [cabal-install-1.24,ghc-7.10.3], sources: [hvr-ghc]}}
     - env: CABALVER=1.24 GHCVER=8.0.1
       compiler: ": #GHC 8.0.1"
       addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.1], sources: [hvr-ghc]}}

--- a/.travis.yml
+++ b/.travis.yml
@@ -76,7 +76,7 @@ before_install:
  - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH
  - if [ "$GHCVER" != "7.2.1" ];
    then
-     export TEST_OPTS=--enable-tests;
+     export TEST_OPTS="--enable-tests --enable-benchmarks";
    fi
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 # This file has been generated -- see https://github.com/hvr/multi-ghc-travis
 language: c
-sudo: false
+sudo: true
 
 cache:
   directories:
@@ -83,9 +83,15 @@ install:
      zcat $HOME/.cabal/packages/hackage.haskell.org/00-index.tar.gz >
           $HOME/.cabal/packages/hackage.haskell.org/00-index.tar;
    fi
+# To avoid a SafeHaskell bug on GHC 7.2.1
+ - if [ "$GHCVER" = "7.2.1" ];
+   then
+     sudo /opt/ghc/$GHCVER/bin/ghc-pkg trust base;
+   fi
  - travis_retry cabal update -v
  - sed -i 's/^jobs:/-- jobs:/' ${HOME}/.cabal/config
- - cabal install --only-dependencies --dry -v > installplan.txt
+# can't use "cabal install --only-dependencies --enable-tests" due to dep-cycle
+ - cabal install 'test-framework == 0.8.*' 'test-framework-hunit == 0.3.*' 'HUnit >= 1.2 && < 1.6' --dry -v > installplan.txt
  - sed -i -e '1,/^Resolving /d' installplan.txt; cat installplan.txt
 
 # check whether current requested install-plan matches cached package-db snapshot
@@ -99,9 +105,9 @@ install:
      echo "cabal build-cache MISS";
      rm -rf $HOME/.cabsnap;
      mkdir -p $HOME/.ghc $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin;
-     cabal install --only-dependencies;
+     cabal install 'test-framework == 0.8.*' 'test-framework-hunit == 0.3.*' 'HUnit >= 1.2 && < 1.6';
    fi
- 
+
 # snapshot package-db on cache miss
  - if [ ! -d $HOME/.cabsnap ];
    then
@@ -115,9 +121,10 @@ install:
 # any command which exits with a non-zero exit code causes the build to fail.
 script:
  - if [ -f configure.ac ]; then autoreconf -i; fi
- - cabal configure -v2  # -v2 provides useful information for debugging
+ - cabal configure --enable-tests -v2  # -v2 provides useful information for debugging
  - cabal build   # this builds all libraries and executables (including tests/benchmarks)
  - cabal sdist   # tests that a source-distribution can be generated
+ - cabal test
 
 # Check that the resulting source distribution can be built & installed.
 # If there are no other `.tar.gz` files in `dist`, this can be even simpler:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 # This file has been generated -- see https://github.com/hvr/multi-ghc-travis
 language: c
-sudo: true
+sudo: false
 
 cache:
   directories:
@@ -74,6 +74,10 @@ matrix:
 before_install:
  - unset CC
  - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH
+ - if [ "$GHCVER" != "7.2.1" ];
+   then
+     export TEST_OPTS=--enable-tests;
+   fi
 
 install:
  - cabal --version
@@ -83,15 +87,15 @@ install:
      zcat $HOME/.cabal/packages/hackage.haskell.org/00-index.tar.gz >
           $HOME/.cabal/packages/hackage.haskell.org/00-index.tar;
    fi
-# To avoid a SafeHaskell bug on GHC 7.2.1
- - if [ "$GHCVER" = "7.2.1" ];
-   then
-     sudo /opt/ghc/$GHCVER/bin/ghc-pkg trust base;
-   fi
  - travis_retry cabal update -v
  - sed -i 's/^jobs:/-- jobs:/' ${HOME}/.cabal/config
 # can't use "cabal install --only-dependencies --enable-tests" due to dep-cycle
- - cabal install 'test-framework == 0.8.*' 'test-framework-hunit == 0.3.*' 'HUnit >= 1.2 && < 1.6' --dry -v > installplan.txt
+ - if [ -n "$TEST_OPTS" ];
+   then
+     cabal install 'test-framework == 0.8.*' 'test-framework-hunit == 0.3.*' 'HUnit >= 1.2 && < 1.6' --dry -v > installplan.txt;
+   else
+     cabal install --only-dependencies --dry -v > installplan.txt;
+   fi
  - sed -i -e '1,/^Resolving /d' installplan.txt; cat installplan.txt
 
 # check whether current requested install-plan matches cached package-db snapshot
@@ -105,7 +109,12 @@ install:
      echo "cabal build-cache MISS";
      rm -rf $HOME/.cabsnap;
      mkdir -p $HOME/.ghc $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin;
-     cabal install 'test-framework == 0.8.*' 'test-framework-hunit == 0.3.*' 'HUnit >= 1.2 && < 1.6';
+     if [ -n "$TEST_OPTS" ];
+     then
+       cabal install -j 'test-framework == 0.8.*' 'test-framework-hunit == 0.3.*' 'HUnit >= 1.2 && < 1.6';
+     else
+       cabal install -j --only-dependencies;
+     fi
    fi
 
 # snapshot package-db on cache miss
@@ -121,10 +130,13 @@ install:
 # any command which exits with a non-zero exit code causes the build to fail.
 script:
  - if [ -f configure.ac ]; then autoreconf -i; fi
- - cabal configure --enable-tests -v2  # -v2 provides useful information for debugging
+ - cabal configure $TEST_OPTS -v2  # -v2 provides useful information for debugging
  - cabal build   # this builds all libraries and executables (including tests/benchmarks)
  - cabal sdist   # tests that a source-distribution can be generated
- - cabal test
+ - if [ -n "$TEST_OPTS" ];
+   then
+     cabal test --show-details=always;
+   fi
 
 # Check that the resulting source distribution can be built & installed.
 # If there are no other `.tar.gz` files in `dist`, this can be even simpler:

--- a/deepseq.cabal
+++ b/deepseq.cabal
@@ -90,7 +90,8 @@ test-suite deepseq-generics-tests
     build-depends:
         array,
         base,
+        ghc-prim,
         -- end of packages with inherited version constraints
         test-framework == 0.8.*,
         test-framework-hunit == 0.3.*,
-        HUnit >= 1.2 && < 1.4
+        HUnit >= 1.2 && < 1.6


### PR DESCRIPTION
Currently, the test suite isn't run on Travis builds. This PR aims to fix that. I had to make some modifications to make this happen:

* Unfortunately, `HUnit` (which we depend on for the test suite) depends on `deepseq`, so trying to naïvely run `cabal install --only-dependencies --enable-tests` will result in a dependency cycle. To get around this, I have to manually specify the dependencies in `.travis.yml` [_à la_ `binary`](https://github.com/kolmodin/binary/blob/3f30c35da4a8c235b75f98cbb8a3584a529cc5fd/.travis.yml#L34-L35).
* ~~Also unfortunately, there's a Safe Haskell bug in GHC 7.2.1 that prevents it from installing `transformers` without running `sudo ghc-pkg trust base`. But in order to use `sudo`, I have to disable the containerized Travis builds.~~ (This isn't true anymore, see https://github.com/haskell/deepseq/pull/24#issuecomment-255169537)
* I needed to bump the upper version bounds on `HUnit` to `< 1.6` to accommodate the `HUnit-1.5` release on Hackage. Also, the test suite failed to build without an explicit `ghc-prim` dependency.