### PR TITLE
Fixing CallStack NFData instance

### DIFF
--- a/Control/DeepSeq.hs
+++ b/Control/DeepSeq.hs
@@ -621,7 +621,7 @@ instance NFData SrcLoc where
 -- |@since 1.4.2.0
 instance NFData CallStack where
   rnf EmptyCallStack = ()
-  rnf (PushCallStack a b c) = rnf a `seq` rnf b `seq` rnf c
+  rnf (PushCallStack (a, b) c) = rnf a `seq` rnf b `seq` rnf c
   rnf (FreezeCallStack a)   = rnf a
 
 #elif MIN_VERSION_base(4,8,1)


### PR DESCRIPTION
When building DeepSeq I receive the following error:
```
deepseq-1.4.3.0: build
Preprocessing library deepseq-1.4.3.0...
[1 of 1] Compiling Control.DeepSeq  ( Control/DeepSeq.hs, .stack-work/dist/x86_64-linux/Cabal-1.23.1.0/build/Control/DeepSeq.o )

/home/nikola/projects/haskell/deepseq/Control/DeepSeq.hs:624:8: error:
    • The constructor ‘PushCallStack’ should have 2 arguments, but has been given 3
    • In the pattern: PushCallStack a b c
      In an equation for ‘rnf’:
          rnf (PushCallStack a b c) = rnf a `seq` rnf b `seq` rnf c
      In the instance declaration for ‘NFData CallStack’

--  While building package deepseq-1.4.3.0 using:
      /home/nikola/.stack/setup-exe-cache/x86_64-linux/setup-Simple-Cabal-1.23.1.0-ghc-8.0.0.20160204 --builddir=.stack-work/dist/x86_64-linux/Cabal-1.23.1.0 build lib:deepseq --ghc-options " -ddump-hi -ddump-to-file"
    Process exited with code: ExitFailure 1

```

Upon inspecting how `CallStack` is defined [(GHC.Stack.Types):](https://hackage.haskell.org/package/base-4.9.0.0/candidate/docs/src/GHC.Stack.Types.html#PushCallStack)

```
-- @since 4.8.1.0
data CallStack
  = EmptyCallStack
  | PushCallStack ([Char], SrcLoc) CallStack
  | FreezeCallStack CallStack
    -- ^ Freeze the stack at the given @CallStack@, preventing any further
    -- call-sites from being pushed onto it.
```

I noticed that CallStack NFData instance assumes PushCallStack constructor takes three arguments, but it really takes two, where first one is a tuple.



This fix allows me to build DeepSeq, but I doubt that such a trivial mistake could've slipped in without anyone noticing, so apart from this fix, are there any other reasons why this issue may occur?

Thank you :)