### PR TITLE
Expose NFData instance for Down on earlier versions of base

### DIFF
--- a/Control/DeepSeq.hs
+++ b/Control/DeepSeq.hs
@@ -88,6 +88,8 @@ import System.Mem.StableName ( StableName )
 
 #if MIN_VERSION_base(4,6,0)
 import Data.Ord ( Down(Down) )
+#else
+import GHC.Exts ( Down(Down) )
 #endif
 
 #if MIN_VERSION_base(4,7,0)
@@ -507,13 +509,11 @@ instance NFData2 Array where
     liftRnf2 r r' x = liftRnf2 r r (bounds x) `seq` liftRnf r' (Data.Array.elems x)
 #endif
 
-#if MIN_VERSION_base(4,6,0)
 -- |@since 1.4.0.0
 instance NFData a => NFData (Down a) where rnf = rnf1
 -- |@since 1.4.3.0
 instance NFData1 Down where
     liftRnf r (Down x) = r x
-#endif
 
 -- |@since 1.4.0.0
 instance NFData a => NFData (Dual a) where rnf = rnf1

--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,7 @@
     ([#13](https://github.com/haskell/deepseq/issues/13))
   * Add `NFData Ordering` ([#25](https://github.com/haskell/deepseq/pull/25))
   * Add `NFData1` and `NFData2` type classes ([#8](https://github.com/haskell/deepseq/issues/8))
+  * Expose `NFData` instance for `Down` on earlier versions of `base`
 
 ## 1.4.2.0  *Apr 2016*
 


### PR DESCRIPTION
Before `Down` was migrated to `Data.Ord` in `base-4.6.0`, it lived in `GHC.Exts`. This means we can expose the `NFData` instance for `Down` unconditionally.

(Progress towards #27).