### PR TITLE
Add NFData instance for Foreign.C.Types.CBool

### DIFF
--- a/Control/DeepSeq.hs
+++ b/Control/DeepSeq.hs
@@ -757,6 +757,11 @@ instance NFData CFpos where rnf = rwhnf
 -- |@since 1.4.0.0
 instance NFData CJmpBuf where rnf = rwhnf
 
+#if MIN_VERSION_base(4,10,0)
+-- | @since 1.4.3.0
+instance NFData CBool where rnf = rwhnf
+#endif
+
 ----------------------------------------------------------------------------
 -- System.Exit
 

--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,7 @@
   * Add `NFData1` and `NFData2` type classes ([#8](https://github.com/haskell/deepseq/issues/8))
   * Add `NFData1` and `NFData` instances for `Data.Functor.{Compose,Sum,Product}`
     ([#30](https://github.com/haskell/deepseq/pull/30))
+  * Add `NFData` instance for `Foreign.C.Types.CBool`
 
 ## 1.4.2.0  *Apr 2016*
 


### PR DESCRIPTION
`CBool` was introduced in `base-4.10.0.0`. Since `deepseq` provides `NFData` instances for all the other datatypes in `Foreign.C.Types`, it seemed natural to add `CBool` to complete the collection.