### PR TITLE
Add NFData instance for MaskingState

### DIFF
--- a/Control/DeepSeq.hs
+++ b/Control/DeepSeq.hs
@@ -87,6 +87,7 @@ module Control.DeepSeq (
 
 import Control.Applicative
 import Control.Concurrent ( ThreadId, MVar )
+import Control.Exception ( MaskingState(..) )
 import Data.IORef
 import Data.STRef
 import Data.Int
@@ -427,6 +428,8 @@ instance NFData Word8    where rnf = rwhnf
 instance NFData Word16   where rnf = rwhnf
 instance NFData Word32   where rnf = rwhnf
 instance NFData Word64   where rnf = rwhnf
+
+instance NFData MaskingState where rnf = rwhnf
 
 #if MIN_VERSION_base(4,7,0)
 -- |@since 1.4.0.0


### PR DESCRIPTION
`Control.Exception.MaskingState` was introduced in `base-4.3`.

With this instance, I can drop two long `NFData` instances in dejafu ([Test/DejaFu/Types.hs#L206](https://github.com/barrucadu/dejafu/blob/b6bce5cec665c3a0bf4a00320b6d112c93923d8a/dejafu/Test/DejaFu/Types.hs#L206) and [#L341](https://github.com/barrucadu/dejafu/blob/b6bce5cec665c3a0bf4a00320b6d112c93923d8a/dejafu/Test/DejaFu/Types.hs#L341)) and just use the default `Generic`-based one, which would be very nice.