### PR TITLE
Add GNFData instance for unboxed types

### DIFF
--- a/Control/DeepSeq.hs
+++ b/Control/DeepSeq.hs
@@ -179,6 +179,13 @@ instance GNFData arity a => GNFData arity (M1 i c a) where
   grnf args = grnf args . unM1
   {-# INLINEABLE grnf #-}
 
+#if __GLASGOW_HASKELL__ >= 800
+  -- @since 1.4.5.0
+instance GNFData arity (URec a) where
+  grnf _ = rwhnf
+  {-# INLINEABLE grnf #-}
+#endif
+
 instance (GNFData arity a, GNFData arity b) => GNFData arity (a :*: b) where
   grnf args (x :*: y) = grnf args x `seq` grnf args y
   {-# INLINEABLE grnf #-}

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Changelog for [`deepseq` package](http://hackage.haskell.org/package/deepseq)
 
+## 1.4.5.0
+
+  * Add `GNFData` for URec
+    This will enable deriving NFData instances for unboxed types
+
 ## 1.4.4.0 *Sep 2018*
 
   * Bundled with GHC 8.6.1


### PR DESCRIPTION
This is needed to derive NFData for datatype which contain unboxed types.

I've assumed that the next release is going to be 1.4.5.0 and I've added a @since directive. If there are other plans for the version of the next release we should make sure to fix that.