### PR TITLE
add more haskell build artifacts to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,8 @@ GNUmakefile
 /dist-install/
 /dist/
 ghc.mk
+/dist/
+/dist-newstyle/
+*.hi
+*.o
+.ghc.environment*

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,8 @@
 GNUmakefile
 /dist-install/
 /dist/
-ghc.mk
-/dist/
 /dist-newstyle/
+ghc.mk
 *.hi
 *.o
 .ghc.environment*


### PR DESCRIPTION
I was surprised to see the .gitignore so bare. I guess most contributors just have these in their global .gitignores? I think having these would be beneficial, and make it easier to stop build artifacts from muddying the tree.