### PR TITLE
Set infixr of 'deepseq' to be consistent with 'seq'

### DIFF
--- a/Control/DeepSeq.hs
+++ b/Control/DeepSeq.hs
@@ -210,6 +210,7 @@ instance (NFData1 f, GNFData One g) => GNFData One (f :.: g) where
     grnf args = liftRnf (grnf args) . unComp1
 
 infixr 0 $!!
+infixr 0 `deepseq`
 
 -- | 'deepseq': fully evaluates the first argument, before returning the
 -- second.

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,8 @@
 
   * Add `GNFData` for URec
     This will enable deriving NFData instances for unboxed types
+  * Set `infixr 0` for `deepseq`
+    Makes infix use of 'deepseq' parse the same way as infix use of 'seq'
 
 ## 1.4.4.0 *Sep 2018*
 


### PR DESCRIPTION
Without this patch the following code:

    a `deepseq` a : as

gets parsed as

    (a `deepseq` a) : as

instead of

    a `deepseq` (a : as)

Note that `seq` already behaves like this.

--------------------

We had similar problems over at [clash-lang/clash-compiler](https://github.com/clash-lang/clash-compiler/pull/1258) for our Clash-specific version of deepseq causing pretty bad memory leaks. 