### PR TITLE
Bump base upper bound to 4.16

### DIFF
--- a/deepseq.cabal
+++ b/deepseq.cabal
@@ -63,7 +63,7 @@ library
   if impl(ghc>=7.8)
     other-extensions: EmptyCase
 
-  build-depends: base       >= 4.5 && < 4.16,
+  build-depends: base       >= 4.5 && < 4.17,
                  array      >= 0.4 && < 0.6
   ghc-options: -Wall
 


### PR DESCRIPTION
Context: https://gitlab.haskell.org/ghc/ghc/-/merge_requests/4082#note_300462