### PR TITLE
version bump: 1.4.4.0 -> 1.4.5.0

### DIFF
--- a/deepseq.cabal
+++ b/deepseq.cabal
@@ -1,6 +1,6 @@
 cabal-version:  1.12
 name:           deepseq
-version:        1.4.4.0
+version:        1.4.5.0
 -- NOTE: Don't forget to update ./changelog.md
 
 license:        BSD3


### PR DESCRIPTION
backports minor version bump for release 1.4.5.0 based on top of 13c1c84415da727ab56e9fa33aca5046b6683848