### PR TITLE
Add Solo instances. Fixes #67

### DIFF
--- a/Control/DeepSeq.hs
+++ b/Control/DeepSeq.hs
@@ -155,6 +155,12 @@ import GHC.SrcLoc ( SrcLoc(..) )
 import GHC.Fingerprint.Type ( Fingerprint(..) )
 import GHC.Generics
 
+#ifdef MIN_VERSION_ghc_prim
+#if MIN_VERSION_ghc_prim(0,7,0)
+import GHC.Tuple (Solo (..))
+#endif
+#endif
+
 -- | Hidden internal type-class
 class GNFData arity f where
   grnf :: RnfArgs arity a -> f a -> ()
@@ -951,6 +957,17 @@ instance NFData CallStack where
 
 ----------------------------------------------------------------------------
 -- Tuples
+
+#ifdef MIN_VERSION_ghc_prim
+#if MIN_VERSION_ghc_prim(0,7,0)
+-- |@since 1.4.6.0
+instance NFData a => NFData (Solo a) where
+  rnf (Solo a) = rnf a
+-- |@since 1.4.6.0
+instance NFData1 Solo where
+  liftRnf r (Solo a) = r a
+#endif
+#endif
 
 instance (NFData a, NFData b) => NFData (a,b) where rnf = rnf2
 -- |@since 1.4.3.0

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,13 @@
 # Changelog for [`deepseq` package](http://hackage.haskell.org/package/deepseq)
 
+## 1.4.6.0
+
+  * Bundled with GHC 9.2.1
+  * Set the `infixr 0 deepseq` to be consistent with `seq`
+    ([#56](https://github.com/haskell/deepseq/pull/56))
+  * Add instances for `Solo` (GHC-9)
+    ([#69](https://github.com/haskell/deepseq/pull/69))
+
 ## 1.4.5.0
 
   * Add `GNFData` for URec

--- a/deepseq.cabal
+++ b/deepseq.cabal
@@ -57,11 +57,16 @@ library
   if impl(ghc == 7.4.*)
     build-depends: ghc-prim == 0.2.*
 
+  -- Solo lives in ghc-prim in GHC-9.0 (and maybe still in GHC-9.2)
+  if impl(ghc >=9.0)
+    build-depends: ghc-prim
+
   if impl(ghc>=7.6)
     other-extensions: PolyKinds
 
   if impl(ghc>=7.8)
     other-extensions: EmptyCase
+
 
   build-depends: base       >= 4.5 && < 4.17,
                  array      >= 0.4 && < 0.6


### PR DESCRIPTION
The `ghc-prim` dependency can be dropped later when `Solo` is available in `base`, it's no harm.