### PR TITLE
Replace the Travis CI Badge with GithubAction CI Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-The `deepseq` Package  [![Hackage](https://img.shields.io/hackage/v/deepseq.svg)](https://hackage.haskell.org/package/deepseq) [![Build Status](https://travis-ci.org/haskell/deepseq.svg)](https://travis-ci.org/haskell/deepseq)
+The `deepseq` Package  [![Hackage](https://img.shields.io/hackage/v/deepseq.svg)](https://hackage.haskell.org/package/deepseq) [![ci](https://github.com/haskell/deepseq/actions/workflows/ci.yml/badge.svg)](https://github.com/haskell/deepseq/actions/workflows/ci.yml)
 =====================
 
 See [`deepseq` on Hackage](http://hackage.haskell.org/package/deepseq) for more information.


### PR DESCRIPTION
The Readme.md currently displays the defunct Travis CI Badge instead of the GithubAction CI Badge.