### PR TITLE
NFData(1) instances of Generically(1).

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog for [`deepseq` package](http://hackage.haskell.org/package/deepseq)
 
+## 1.4.??
+
+  * Add instances for `Generically` and `Generically1`. `NFData A`
+    can now be derived via `Generically A` for `Generic A`.
+    `NFData1 F` can be derived via `Generically1 F` for `Generic1 F`.
+
 ## 1.4.7.0
 
   * Add instances for `Solo` (GHC-9)


### PR DESCRIPTION
Generic instances of `NFData` and `NFData1`, and documentation.

```haskell
instance (Generic a, GNFData Zero (Rep a)) => NFData (Generically a) where
  rnf :: Generically a -> ()
  rnf (Generically a) = grnf RnfArgs0 (from a)

instance (Generic1 f, GNFData One (Rep1 f)) => NFData1 (Generically1 f) where
  liftRnf :: (a -> ()) -> (Generically1 f a -> ())
  liftRnf r (Generically1 as) = grnf (RnfArgs1 r) (from1 as)
```