### PR TITLE
Adapt the rename of the Solo constructor to MkSolo

### DIFF
--- a/Control/DeepSeq.hs
+++ b/Control/DeepSeq.hs
@@ -879,10 +879,18 @@ instance NFData CallStack where
 #if MIN_VERSION_ghc_prim(0,7,0)
 -- |@since 1.4.6.0
 instance NFData a => NFData (Solo a) where
+#if MIN_VERSION_ghc_prim(0,10,0)
+  rnf (MkSolo a) = rnf a
+#else
   rnf (Solo a) = rnf a
+#endif
 -- |@since 1.4.6.0
 instance NFData1 Solo where
+#if MIN_VERSION_ghc_prim(0,10,0)
+  liftRnf r (MkSolo a) = r a
+#else
   liftRnf r (Solo a) = r a
+#endif
 #endif
 #endif
 


### PR DESCRIPTION
Part of the proposal https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0475-tuple-syntax.rst

Tracked by https://gitlab.haskell.org/ghc/ghc/-/issues/21294