### PR TITLE
Bump bounds to accommodate base-4.18

### DIFF
--- a/deepseq.cabal
+++ b/deepseq.cabal
@@ -59,7 +59,7 @@ library
   if impl(ghc >=9.0)
     build-depends: ghc-prim
 
-  build-depends: base       >= 4.9 && < 4.18,
+  build-depends: base       >= 4.9 && < 4.19,
                  array      >= 0.4 && < 0.6
   ghc-options: -Wall
 


### PR DESCRIPTION
In service of GHC 9.6.1.