### PR TITLE
Deprecate function instance

### DIFF
--- a/Control/DeepSeq.hs
+++ b/Control/DeepSeq.hs
@@ -531,7 +531,7 @@ instance NFData1 Fixed where liftRnf _ = rwhnf
 --  This assumes that WHNF is equivalent to NF for functions.
 --
 --  @since 1.3.0.0
---  @deprecated 1.5.1.1
+--  @deprecated 1.5.2.0
 #if __GLASGOW_HASKELL__ >= 910
 instance {-# DEPRECATED "NFData is not well-defined on function types. https://github.com/haskell/deepseq/issues/16" #-} NFData (a -> b) where rnf = rwhnf
 #else

--- a/Control/DeepSeq.hs
+++ b/Control/DeepSeq.hs
@@ -531,7 +531,12 @@ instance NFData1 Fixed where liftRnf _ = rwhnf
 --  This assumes that WHNF is equivalent to NF for functions.
 --
 --  @since 1.3.0.0
+--  @deprecated 1.5.1.1
+#if __GLASGOW_HASKELL__ >= 910
+instance {-# DEPRECATED "functions cannot be in normal form" #-} NFData (a -> b) where rnf = rwhnf
+#else
 instance NFData (a -> b) where rnf = rwhnf
+#endif
 
 -- Rational and complex numbers.
 

--- a/Control/DeepSeq.hs
+++ b/Control/DeepSeq.hs
@@ -533,7 +533,7 @@ instance NFData1 Fixed where liftRnf _ = rwhnf
 --  @since 1.3.0.0
 --  @deprecated 1.5.1.1
 #if __GLASGOW_HASKELL__ >= 910
-instance {-# DEPRECATED "functions cannot be in normal form" #-} NFData (a -> b) where rnf = rwhnf
+instance {-# DEPRECATED "NFData is not well-defined on function types. https://github.com/haskell/deepseq/issues/16" #-} NFData (a -> b) where rnf = rwhnf
 #else
 instance NFData (a -> b) where rnf = rwhnf
 #endif

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,10 @@
 
 ## Upcoming
 
+## 1.5.1.1
 
+  * Deprecate function instance of NFData
+    ([#16](https://github.com/haskell/deepseq/issues/16), [#109](https://github.com/haskell/deepseq/issues/109))
 
 ## 1.5.1.0
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 ## Upcoming
 
-## 1.5.1.1
+## 1.5.2.0
 
   * Deprecate function instance of NFData
     ([#16](https://github.com/haskell/deepseq/issues/16), [#109](https://github.com/haskell/deepseq/issues/109))

--- a/deepseq.cabal
+++ b/deepseq.cabal
@@ -1,6 +1,6 @@
 cabal-version:  1.12
 name:           deepseq
-version:        1.5.1.1
+version:        1.5.2.0
 -- NOTE: Don't forget to update ./changelog.md
 
 license:        BSD3

--- a/deepseq.cabal
+++ b/deepseq.cabal
@@ -1,6 +1,6 @@
 cabal-version:  1.12
 name:           deepseq
-version:        1.5.1.0
+version:        1.5.1.1
 -- NOTE: Don't forget to update ./changelog.md
 
 license:        BSD3


### PR DESCRIPTION
As per #16 (https://github.com/haskell/deepseq/issues/16#issuecomment-2959570459), deprecate the function instance.

Currently I add CPP so that old versions can still compile, which obviously adds a hole in the deprecation plan.

The warning text can be easily adjusted.

```
> deepseq (\x->x+1) `seq` ()
<interactive>:3:1: warning: [GHC-68441] [-Wdeprecations]
    In the use of
      instance NFData (a -> b) -- Defined at Control/DeepSeq.hs:536:66
    arising from a use of ‘deepseq’
    Deprecated: "functions cannot be in normal form"

<interactive>:3:1: warning: [GHC-68441] [-Wdeprecations]
    In the use of
      instance NFData (a -> b) -- Defined at Control/DeepSeq.hs:536:66
    arising from a use of ‘deepseq’
    Deprecated: "functions cannot be in normal form"

()
```
